### PR TITLE
go-frp: use initFuncs to add click handlers after writing the DOM

### DIFF
--- a/examples/1/counter/counter_test.go
+++ b/examples/1/counter/counter_test.go
@@ -14,7 +14,7 @@ func TestView(t *testing.T) {
 		"-</button>",
 		"+</button>",
 	}
-	got := v.String()
+	got, _ := v.Render()
 	for _, w := range want {
 		if !strings.Contains(got, w) {
 			t.Errorf("View = %q, want %q", got, w)

--- a/examples/2/counter/counter_test.go
+++ b/examples/2/counter/counter_test.go
@@ -14,7 +14,7 @@ func TestView(t *testing.T) {
 		"-</button>",
 		"+</button>",
 	}
-	got := v.String()
+	got, _ := v.Render()
 	for _, w := range want {
 		if !strings.Contains(got, w) {
 			t.Errorf("View = %q, want %q", got, w)

--- a/examples/2/counterpair/counterpair_test.go
+++ b/examples/2/counterpair/counterpair_test.go
@@ -18,7 +18,7 @@ func TestView(t *testing.T) {
 		"+</button>",
 		"Reset</button>",
 	}
-	got := v.String()
+	got, _ := v.Render()
 	for _, w := range want {
 		if !strings.Contains(got, w) {
 			t.Errorf("View = %q, want %q", got, w)

--- a/examples/3/counter/counter_test.go
+++ b/examples/3/counter/counter_test.go
@@ -14,7 +14,7 @@ func TestView(t *testing.T) {
 		"-</button>",
 		"+</button>",
 	}
-	got := v.String()
+	got, _ := v.Render()
 	for _, w := range want {
 		if !strings.Contains(got, w) {
 			t.Errorf("View = %q, want %q", got, w)

--- a/examples/3/counterlist/counterlist_test.go
+++ b/examples/3/counterlist/counterlist_test.go
@@ -18,7 +18,7 @@ func TestView(t *testing.T) {
 		"Reset</button>",
 		"Add</button>",
 	}
-	got := v.String()
+	got, _ := v.Render()
 	for _, w := range want {
 		if !strings.Contains(got, w) {
 			t.Errorf("View = %q, want %q", got, w)

--- a/examples/clearfield/clearfield/clearfield_test.go
+++ b/examples/clearfield/clearfield/clearfield_test.go
@@ -13,7 +13,7 @@ func TestView(t *testing.T) {
 		"<input></input>",
 		"Clear</button>",
 	}
-	got := v.String()
+	got, _ := v.Render()
 	for _, w := range want {
 		if !strings.Contains(got, w) {
 			t.Errorf("View = %q, want %q", got, w)

--- a/examples/label/label/label_test.go
+++ b/examples/label/label/label_test.go
@@ -6,7 +6,7 @@ func TestView(t *testing.T) {
 	m := Model(0)
 	v := m.View()
 	want := `<div><input></input><label></label></div>`
-	if got := v.String(); got != want {
+	if got, _ := v.Render(); got != want {
 		t.Errorf("View = %q, want %q", got, want)
 	}
 }

--- a/examples/reverse/reverse/reverse_test.go
+++ b/examples/reverse/reverse/reverse_test.go
@@ -6,7 +6,7 @@ func TestView(t *testing.T) {
 	m := Model(0)
 	v := m.View()
 	want := `<div><input></input><label></label></div>`
-	if got := v.String(); got != want {
+	if got, _ := v.Render(); got != want {
 		t.Errorf("View = %q, want %q", got, want)
 	}
 }

--- a/html/html.go
+++ b/html/html.go
@@ -1,7 +1,15 @@
 // Package html provides functions to build up the DOM of an app.
 package html
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"honnef.co/go/js/dom"
+)
+
+var nextID int // Keep all HTML IDs unique.
 
 // type Action func(App) App
 //
@@ -16,17 +24,21 @@ import "fmt"
 // HTML defines an HTML element.
 type HTML struct {
 	tag    string
+	id     string
 	props  [][]string
 	styles [][]string
 	body   string
 	elems  []HTML
 	// address Address
-	onClick interface{}
+	// onClick interface{}
+	initFuncs []func()
 }
 
-// String renders the HTML element into its string representation.
-func (s HTML) String() string {
+// Render renders the HTML element into its string representation.
+// It also surfaces all initFuncs to the top and returns them.
+func (s HTML) Render() (string, []func()) {
 	var result string
+	var initFuncs []func()
 	if s.tag != "" {
 		result = "<" + s.tag
 		for _, v := range s.props {
@@ -42,13 +54,16 @@ func (s HTML) String() string {
 		result += ">"
 	}
 	for _, v := range s.elems {
-		result += v.String()
+		str, ifs := v.Render()
+		result += str
+		initFuncs = append(initFuncs, ifs...)
 	}
+	initFuncs = append(initFuncs, s.initFuncs...)
 	result += s.body
 	if s.tag != "" {
 		result += "</" + s.tag + ">"
 	}
-	return result
+	return result, initFuncs
 }
 
 // Props adds a slice of properties to an HTML element.
@@ -63,15 +78,53 @@ func (s HTML) Style(styles [][]string) HTML {
 	return s
 }
 
+// ID returns the current HTML ID of this element (assigning if necessary).
+func (s *HTML) ID() string {
+	if s.id != "" {
+		return s.id
+	}
+	// Check the properties to see if the user created an ID for the element.
+	for _, p := range s.props {
+		if p[0] == "id" || p[0] == "ID" {
+			s.id = p[1]
+			return s.id
+		}
+	}
+	// Use the next-available numeric ID and bump it.
+	s.id = strconv.Itoa(nextID)
+	s.props = append(s.props, []string{"id", s.id})
+	nextID++
+	return s.id
+}
+
 // OnClick adds an onClick handler to an HTML element.
 func (s HTML) OnClick(model interface{}, action interface{}) HTML {
 	// log.Printf("GML: OnClick... model=%#v, action=%#v", model, action)
 	// s.address = address
-	s.onClick = action
-	s.props = append(s.props, []string{"onclick", "OnClickHandler()"})
+	// s.onClick = action
+	// s.props = append(s.props, []string{"onclick", "OnClickHandler()"})
 	// use channels?
 	// use an anonymous function?
 	// js.Global.Get("myButton").Call("addEventListener", "click", func() { go func() {...}})
+	id := s.ID()
+	log.Printf("GML: creating element ID: s=%#v, model=%#v, id=%q", s, model, id)
+	s.initFuncs = append(s.initFuncs, func() {
+		log.Printf("GML: firing initFunc! s=%#v, model=%#v, id=%q", s, model, id)
+		d := dom.GetWindow().Document()
+		el := d.GetElementByID(id)
+		el.AddEventListener("click", false, func(e dom.Event) {
+			go func() {
+				log.Printf("GML: in click handler! e=%#v, s=%#v, model=%#v, id=%q", e, s, model, id)
+				// The following causes these errors: "Uncaught Error: reflect: call of ?FIXME? on func Value"
+				// m := reflect.ValueOf(model)
+				// log.Printf("GML: model=%#v, m=%#v, m.Type=%q, m.NumField=%v", model, m, m.Type(), m.NumField())
+				// a := reflect.ValueOf(action)
+				// log.Printf("GML: action=%#v, a=%#v, a.Type=%q, a.NumField=%v", action, a, a.Type(), a.NumField())
+				// newModel := action(model)
+				// log.Printf("GML: in click handler! newModel=%#v", newModel)
+			}()
+		})
+	})
 	return s
 }
 

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -1,0 +1,22 @@
+package html
+
+import (
+	"testing"
+)
+
+func TestID(t *testing.T) {
+	tests := []struct {
+		el   HTML
+		want string
+	}{
+		{el: HTML{id: ""}, want: "0"},
+		{el: HTML{id: ""}, want: "1"}, // auto-increment
+		{el: HTML{id: "user-defined-cached"}, want: "user-defined-cached"},
+		{el: HTML{props: [][]string{{"yo", "ho"}, {"id", "user-defined-not-cached"}}}, want: "user-defined-not-cached"},
+	}
+	for _, test := range tests {
+		if got := test.el.ID(); got != test.want {
+			t.Errorf("ID %#v = %q, want %q", test, got, test.want)
+		}
+	}
+}

--- a/start/start.go
+++ b/start/start.go
@@ -2,8 +2,6 @@
 package start
 
 import (
-	"log"
-
 	h "github.com/gmlewis/go-frp/html"
 	"github.com/gopherjs/gopherjs/js"
 )
@@ -22,11 +20,9 @@ type Model interface {
 // TODO(gmlewis): Support event handling and signals.
 func Start(model Model) {
 	v := model.View()
-	js.Global.Get("document").Call("write", v.String())
-	js.Global.Set("OnClickHandler", OnClickHandler)
-}
-
-// OnClickHandler handles click events
-func OnClickHandler() {
-	log.Printf("OnClickHandler")
+	str, initFuncs := v.Render()
+	js.Global.Get("document").Call("write", str)
+	for _, initFunc := range initFuncs {
+		initFunc()
+	}
 }


### PR DESCRIPTION
The current challenge is that the "reflect" package doesn't appear
to be supported in GopherJS. I would like to use "reflect" in order
to call the provided "update" function on the current model to
generate a new model and then re-render the whole document with the
new model. The provided "update" function takes the current model
and returns a new model and understands the model's type... so this
all should be possible with "reflect".

Eventually, I would like to include a virtual DOM, check the diffs,
and only re-render the portion of the DOM that has changed.

Baby steps.

Change-Id: Ia6f275356bc71cb12dd5b4db083e45fc6f6f0e48
